### PR TITLE
Fix: Version of python image fixed to 3.8 to allow build

### DIFF
--- a/docker-nodemon/Dockerfile
+++ b/docker-nodemon/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.8
 
 VOLUME /setup
 VOLUME /openleadr-python


### PR DESCRIPTION
Build would fail due to dependencies on python>3.8 . Fixed Python version. 

Recommended: Updated  requirements.txt and add missing apt-get in Dockerfile.